### PR TITLE
changing "/usr/bin/perl" to "/usr/bin/env perl" so it will use whatever p

### DIFF
--- a/t/00_public.t
+++ b/t/00_public.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings FATAL => 'all';

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Basic mod_auth_tkt testing, with minimal config
 #

--- a/t/01_relative.t
+++ b/t/01_relative.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Basic mod_auth_tkt testing, with minimal config
 #

--- a/t/02_bad.t
+++ b/t/02_bad.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Test various bad ticket formats
 #

--- a/t/03_ignore_ip.t
+++ b/t/03_ignore_ip.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Testing with TKTAuthIgnoreIP on
 #

--- a/t/05_tokens.t
+++ b/t/05_tokens.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Token testing
 #

--- a/t/07_guest_login.t
+++ b/t/07_guest_login.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Guest login testing
 #

--- a/t/07_guest_login_nocookie.t
+++ b/t/07_guest_login_nocookie.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Guest login testing
 #

--- a/t/08_guest_user.t
+++ b/t/08_guest_user.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Guest user testing
 #

--- a/t/09_guest_not_allowed.t
+++ b/t/09_guest_not_allowed.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Test guest exclusion
 #

--- a/t/10_cookie_expiry.t
+++ b/t/10_cookie_expiry.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Cookie expiry testing
 #

--- a/t/12_cookie_secure.t
+++ b/t/12_cookie_secure.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Testing TKTAuthCookieSecure flag
 #

--- a/t/15_secret_old.t
+++ b/t/15_secret_old.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Testing fallback to secret_old
 #

--- a/t/20_timeout.t
+++ b/t/20_timeout.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Test auth ticket timeouts (TKTAuthTimeoutMin set to 1)
 #

--- a/t/21_timeout_refresh.t
+++ b/t/21_timeout_refresh.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Test auth ticket timeouts (TKTAuthTimeoutMin set to 1)
 #

--- a/t/22_timeout_guest_fallback.t
+++ b/t/22_timeout_guest_fallback.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Test auth ticket timeouts with Guest Fallback on (TKTAuthTimeoutMin set to 1)
 #

--- a/t/30_vhost_local_secret.t
+++ b/t/30_vhost_local_secret.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Virtual host mod_auth_tkt testing, local secret
 #

--- a/t/31_vhost_global_secret.t
+++ b/t/31_vhost_global_secret.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Virtual host mod_auth_tkt testing, global secret
 #

--- a/t/40_htaccess.t
+++ b/t/40_htaccess.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Configuration via .htaccess file
 #

--- a/t/50_bug_cookie_name.t
+++ b/t/50_bug_cookie_name.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Bug in mod_auth_tkt <= 2.0.99b1 would match a partial cookie name,
 # using the wrong ticket to try and authenticate against, resulting

--- a/t/TEST
+++ b/t/TEST
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 package MAT::TestRun;
 use base 'Apache::TestRun';


### PR DESCRIPTION
changing "/usr/bin/perl" to "/usr/bin/env perl" so it will use whatever perl the users environment is configured to use
