### PR TITLE
Added TKTAuthGuestEmpty configuration option

### DIFF
--- a/doc/mod_auth_tkt.pod
+++ b/doc/mod_auth_tkt.pod
@@ -161,6 +161,16 @@ TKTAuthGuestLogin on, of course.
 
 Default: off.
 
+=item TKTAuthGuestEmpty <boolean>
+
+Flag to indicate that the guest username should be an empty
+string.  Useful for allowing applications to fallback to native
+authentication when REMOTE_USER is empty (NOTE: REMOTE_USER must
+exist to satisfy Require valid-user, but will be empty).  Only makes
+sense with TKTAuthGuestLogin on, of course.
+
+Default: off.
+
 =item TKTAuthTimeout <seconds>
 
 The ticket timeout period, in seconds. After this period, the ticket

--- a/t/11_guest_empty.t
+++ b/t/11_guest_empty.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+#
+# Guest login testing
+#
+
+use strict;
+use warnings FATAL => 'all';
+
+use Apache::Test;
+use Apache::TestUtil;
+use Apache::TestRequest qw(GET);
+use HTTP::Cookies;
+use lib "cgi";
+use Apache::AuthTkt;
+
+plan tests => 6, need_lwp;
+
+# Turn off automatic redirection following
+Apache::TestRequest::user_agent(
+  requests_redirectable => 0,
+  reset => 1, 
+);
+
+ok 1;   # simple load test
+
+my $url = '/secret_guest_empty/index.cgi';
+my $res = GET $url;
+
+# Generate ticket and cookie jar
+my $at = Apache::AuthTkt->new(conf => 't/conf/extra.conf');
+my $ticket = $at->ticket(uid => 'testuser', ip_addr => '127.0.0.1');
+my $jar = HTTP::Cookies->new;
+$jar->set_cookie(1, 'auth_tkt', $ticket, '/', '.localdomain');
+# print $jar->as_string;
+
+# Reset the TestRequest user_agent to use our cookie jar
+Apache::TestRequest::user_agent(
+  cookie_jar => $jar,
+  requests_redirectable => 0,
+  reset => 1, 
+);
+
+# Retest with valid cookie - should NOT redirect
+$res = GET $url;
+ok t_cmp($res->code, 200, 'accepted with valid ticket');
+ok t_cmp($res->content, qr/^This is secret_guest_empty, you are testuser\./i, 'accepted testuser');
+
+# Test with no cookie - should accept as guest login, but username should be ''
+# and not set a cookie
+$jar->clear;
+$res = GET $url;
+ok t_cmp($res->code, 200, 'accepted without valid ticket');
+ok t_cmp($res->content, qr/^This is secret_guest_empty, you are \./i, 'accepted as empty guest');
+ok t_cmp($jar->as_string, '', 'NO auth_tkt cookie set');
+
+# vim:sw=2:et:sm:smartindent:ft=perl
+

--- a/t/Makefile
+++ b/t/Makefile
@@ -50,7 +50,7 @@ test_sha512: $(MODULE)
 	./TEST
 
 test: $(MODULE) test_md5 test_sha256 test_sha512
-	
+
 clean:
 	./TEST -clean
 	rm -f conf/extra.conf.in

--- a/t/extra.conf.1.in
+++ b/t/extra.conf.1.in
@@ -68,6 +68,16 @@ TKTAuthDigestType "MD5"
   TKTAuthGuestLogin on
 </Location>
 
+# secret_guest_empty - empty guest testing (uses a CGI)
+<Location /secret_guest_empty>
+  AddHandler cgi-script .cgi
+  Options +ExecCGI
+  AuthType None
+  require valid-user
+  TKTAuthGuestLogin on
+  TKTAuthGuestEmpty on
+</Location>
+
 # secret_guest_user - guest user testing (uses a CGI)
 <Location /secret_guest_user>
   AddHandler cgi-script .cgi

--- a/t/extra.conf.2.in
+++ b/t/extra.conf.2.in
@@ -67,6 +67,16 @@ TKTAuthDigestType "MD5"
   TKTAuthGuestLogin on
 </Location>
 
+# secret_guest_empty - empty guest testing (uses a CGI)
+<Location /secret_guest_empty>
+  AddHandler cgi-script .cgi
+  Options +ExecCGI
+  AuthType None
+  require valid-user
+  TKTAuthGuestLogin on
+  TKTAuthGuestEmpty on
+</Location>
+
 # secret_guest_user - guest user testing (uses a CGI)
 <Location /secret_guest_user>
   AddHandler cgi-script .cgi

--- a/t/htdocs/secret_guest_empty/index.cgi
+++ b/t/htdocs/secret_guest_empty/index.cgi
@@ -1,0 +1,6 @@
+#!/usr/bin/env perl
+print <<EOD
+Content-Type: text/plain
+
+This is secret_guest_empty, you are $ENV{REMOTE_USER}.
+EOD


### PR DESCRIPTION
Added TKTAuthGuestEmpty to allow fallback to native application
authorization on guest logins.  If set to on, then guests
will have a REMOTE_USER of "" (empty string).  Many http-auth
systems will then allow authentication to be handled by the next
highest authenticator (or a built-in default).

Updated doc and test suites as well.