### PR TITLE
Cookie headers with whitespace stripped causing cookie_match to fail.

### DIFF
--- a/src/mod_auth_tkt.c
+++ b/src/mod_auth_tkt.c
@@ -1,4 +1,3 @@
-
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
@@ -627,7 +626,7 @@ cookie_match(void *result, const char *key, const char *cookie)
     value = (char*) cookie;
     while ((value = strstr(value, cookie_name))) {
       /* cookie_name must be preceded by a space or be at the very beginning */
-      if (value > cookie && *(value-1) != ' ') {
+      if (value > cookie && (*(value-1) != ' ' && *(value-1) != ';')) {
         value++;
         continue;
       }


### PR DESCRIPTION
some badly behaved proxy/cache servers strip whitespace from headers, which results in a failure to parse the cookie correctly.
this will allow for that.