### PR TITLE
Dev

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Requires: an apache with DSO support, either 1.3.x, 2.0.x, or 2.2.x.
+Requires: an apache with DSO support, either 1.3.x, 2.0.x, 2.2.x, or 2.4.x.
 
   $ ./configure --apxs=/path/to/apxs
   $ make

--- a/README.Apache_2.4
+++ b/README.Apache_2.4
@@ -1,0 +1,45 @@
+Upgrading to Apache 2.4
+-----------------------
+
+Starting with version 2.2.0, mod_auth_tkt supports Apache 2.4
+taking advantage of the new "provider" model for authentication/
+authorization.
+
+In particular, mod_auth_tkt now acts as an authorization provider
+and allows you to use the much more versatile 'Require' directive
+instead of TKTAuthToken:
+
+  Require tkt-group token1 token2 ...
+
+Note that the "entity-name" needs to be 'tkt-group' and not
+just 'group' to direct the check to mod_auth_tkt (this also
+applies for similar modules, e.g. mod_auth_dbm -> dbm-group
+and is *not* documented in the Apache 2.4 doc).
+
+The remainder of the directive is a list of one or more tokens
+of which at least one must be present in the ticket for a user
+to be granted access to the resource.
+
+Using the standard 'Require' directive together with the new
+<RequireAny/All> sections allows to build arbitrarily complex
+access control expressions.
+
+Example config:
+
+   TKTAuthSecret       "my shared secret"
+   <Location "/">
+      TKTAuthLoginURL  https://sso.some.where/login
+      TKTAuthDomain    .some.where
+      #
+      Order            allow,deny
+      Allow            from all
+      Require          all granted
+   </Location>
+
+   <Location "/jackpot">
+      Require         tkt-group  gamblers taxpayers
+   </Location>
+
+Note that there are no AuthBasic* directives anywhere.
+On authorization failure, the session is immediately
+redirected to the error page.

--- a/configure
+++ b/configure
@@ -5,6 +5,7 @@
 
 # Defaults
 APXS=/usr/sbin/apxs
+test -x $APXS || APXS=/usr/bin/apxs2
 test -x $APXS || unset APXS
 
 ME=`basename $0`
@@ -14,7 +15,7 @@ if [ $DIR = '.' ]; then
 fi
 
 usage() {
-  echo "usage: $ME [--apxs=/path/to/apxs] [--apachever=<1|2|2.2>] [--debug]"
+  echo "usage: $ME [--apxs=/path/to/apxs] [--apachever=<1|2|2.2|2.4>] [--debug]"
 }
 die() {
   echo $*
@@ -62,14 +63,15 @@ test -x $APXS || die "Error: missing apxs '$APXS' (use --apxs=/path/to/apxs)"
 # Get Apache version
 if [ -z "$VERSION" ]; then
   HTTPD=`$APXS -q SBINDIR`/`$APXS -q TARGET`
-  test -x $HTTPD || die "Error: cannot determine apache version (use --apachever=<1|2|2.2>)"
+  test -x $HTTPD || die "Error: cannot determine apache version (use --apachever=<1|2|2.2|2.4>)"
   VERSION=`$HTTPD -v | head -1 | sed -e 's/.*Apache\///' -e 's/^\([0-9]\.[0-9]\+\).*/\1/'`
 fi
 # Standardise
 test $VERSION = '2.0' && VERSION=2
 test $VERSION = '20'  && VERSION=2
 test $VERSION = '22'  && VERSION=2.2
-if [ $VERSION != '1' -a $VERSION != '2' -a $VERSION != '2.2' ]; then
+test $VERSION = '24'  && VERSION=2.4
+if [ $VERSION != '1' -a $VERSION != '2' -a $VERSION != '2.2' -a $VERSION != '2.4' ]; then
   die "Error: apache version '$VERSION' not supported"
 fi
 
@@ -89,8 +91,14 @@ if [ "$VERSION" = "1" ]; then
   echo "CFLAGS += -DAPACHE13" >> Makedefs
   echo "TARGET = mod_auth_tkt.so" >> Makedefs
 else
+  if [ $VERSION = "2" ]; then
+    echo "CFLAGS += -DAPACHE20" >> Makedefs
+  fi
   if [ $VERSION = "2.2" ]; then
     echo "CFLAGS += -DAPACHE22" >> Makedefs
+  fi
+  if [ $VERSION = "2.4" ]; then
+    echo "CFLAGS += -DAPACHE24" >> Makedefs
   fi
   echo "TARGET = mod_auth_tkt.la" >> Makedefs
 fi

--- a/doc/mod_auth_tkt.pod
+++ b/doc/mod_auth_tkt.pod
@@ -337,6 +337,37 @@ see these messages.
 
 =back
 
+=head2 Apache 2.4 Specifics
+
+one of the new features of Apache 2.4 is a framework
+for authentication and authorization providers.
+mod_auth_tkt registers itself as an authorization
+provider, invoked when the standard C<Require> directive
+is followed by the entity type C<tkt-group> and one
+more "groups", i.e. tokens in the ticket.
+This is more general approach than C<TKTAuthToken>,
+since these directives can be combined to build
+arbitarily complex access control expressions.
+
+The server now uses the IP address of the user agent
+instead of the connection endpoint, which makes it more
+useful in a load-balancer or proxy environment.
+
+mod_auth_tkt now passes the authenticated username
+to applications in a fake authentication header.
+
+=over 4
+
+=item Require tkt-group <tokens...>
+
+mod_auth_tkt allows to use tokens in the same way as you would
+use groups in a C<Require> directive.
+The directive grants access if the current ticket contains at
+least one of the tokens listed in the directive.
+C<Require tkt-group> also triggers authentication through mod_auth_tkt.
+
+=back
+
 =head1 EXAMPLES
 
 Minimal config using logins:
@@ -380,6 +411,15 @@ Example intranet configuration:
     TKTAuthPostTimeoutURL https://www.example.com/auth/login.cgi?timeout=1&post=1
     TKTAuthTimeout 4h
     TKTAuthCookieExpires 4h
+  </Location>
+
+
+Example Apache 2.4 configuration using groups/tokens:
+
+  <Location /secret5>
+    AuthType None
+    require tkt-group token1 token2
+    TKTAuthLoginURL https://www.example.com/auth/login.cgi
   </Location>
 
 

--- a/src/mod_auth_tkt.c
+++ b/src/mod_auth_tkt.c
@@ -273,11 +273,10 @@ set_auth_tkt_token (cmd_parms *cmd, void *cfg, const char *param)
   auth_tkt_dir_conf *conf = (auth_tkt_dir_conf *) cfg;
 
 #ifdef APACHE24
-  ap_log_error(APLOG_MARK, APLOG_WARNING, 0, cmd->server,
-  "As of Apache 2.4, TKTAuthToken is deprecated in favor "
-  "of the more versatile standard directive "
-  "'Require tkt-group group1 group2 ...' "
-  "(see README.Apache_2.4 for more information).");
+  ap_log_error(APLOG_MARK, APLOG_INFO, 0, cmd->server,
+  "With Apache 2.4, 'Require tkt-group group1 group2 ...' "
+  "is a more versatile alternative to TKTAuthToken (see "
+  "README.Apache_2.4 or the manpage for more information).");
 #endif
 
   new = (char **) apr_array_push(conf->auth_token);
@@ -1396,10 +1395,15 @@ get_guest_uid(request_rec *r, auth_tkt_dir_conf *conf)
   int guest_user_length;
   apr_uuid_t *uuid;
   char *uuid_str, *uuid_length_str;
-#ifndef APACHE22
+#ifdef APACHE20
   regex_t *uuid_regex;
   regmatch_t regm[UUID_SUBS];
-#else
+#endif
+#ifdef APACHE22
+  ap_regex_t *uuid_regex;
+  ap_regmatch_t regm[UUID_SUBS];
+#endif
+#ifdef APACHE24
   ap_regex_t *uuid_regex;
   ap_regmatch_t regm[UUID_SUBS];
 #endif


### PR DESCRIPTION
Hi Gavin,

thanks for this wonderful piece of software which we've been using for quite a few years now.

With some pressure from Ubuntu 14 LTS to move to Apache 2.4, I had to adapt it to run with it. In doing so, I also enabled it to benefit from the new authorization provider API.

Along the way, I also made a small correction to inconsistent char/char* use of the query_separator which caused Apache to sometimes core dump.

Greetings from Austria to Australia,
  Dietmar