### PR TITLE
Copy Host header before modifying in get_domain()

### DIFF
--- a/src/mod_auth_tkt.c
+++ b/src/mod_auth_tkt.c
@@ -674,6 +674,10 @@ get_domain(request_rec *r, auth_tkt_dir_conf *conf)
   if (!domain) domain = (char *) apr_table_get(r->headers_in, "X-Forwarded-Host");
   if (!domain) domain = (char *) apr_table_get(r->headers_in, "Host");
   if (domain) {
+    char domain_copy[1000];
+    strcpy(domain_copy, domain);
+    domain = domain_copy;
+
     /* Ignore any trailing port in domain */
     if ((p = ap_strchr(domain, ':'))) {
       *p = '\0';


### PR DESCRIPTION
At the moment get_domain() will strip the port number from the original Host header, meaning that subsequent functions that use the header will find it missing the port number. For example, redirect() calls get_domain() before itself retrieving the Host header, so the port number will always be gone before redirect() can get it.