### PR TITLE
Build breaks if MANPATH contains multiple directories

### DIFF
--- a/configure
+++ b/configure
@@ -14,8 +14,20 @@ if [ $DIR = '.' ]; then
   DIR=`pwd`
 fi
 
+# find default MANDIR
+if [ -d /usr/share/man ]; then
+  MANDIR=/usr/share/man
+elif [ -d /usr/man ]; then
+  MANDIR=/usr/man
+elif [ "$MANPATH" != "" ]; then
+  # choose first dir in MANPATH
+  MANDIR="${MANPATH%%:*}"
+else
+  MANDIR=/usr/share/man
+fi
+
 usage() {
-  echo "usage: $ME [--apxs=/path/to/apxs] [--apachever=<1|2|2.2>] [--debug]"
+  echo "usage: $ME [--apxs=${APXS:-/path/to/apxs}] [--apachever=<1|2|2.2|2.4>] [--mandir=$MANDIR] [--debug]"
 }
 die() {
   echo $*
@@ -38,6 +50,10 @@ do
 	  APXS=$ac_optarg ;;
       --apxs)
 	  ac_prev=APXS ;;
+      --mandir=*)
+	  MANDIR=$ac_optarg ;;
+      --mandir)
+	  ac_prev=MANDIR ;;
       --apachever=*)
 	  VERSION=$ac_optarg ;;
       --debug)
@@ -94,16 +110,7 @@ else
   echo "TARGET = mod_auth_tkt.la" >> Makedefs
 fi
 echo "BASEDIR = $DIR" >> Makedefs
-
-if [ "$MANPATH" != "" ]; then
-    echo "MANPATH = $MANPATH" >> Makedefs
-else
-  if [ -d /usr/share/man ]; then
-    echo "MANPATH = /usr/share/man" >> Makedefs
-  else
-    echo "MANPATH = /usr/man" >> Makedefs
-  fi
-fi
+echo "MANPATH = $MANDIR" >> Makedefs
 
 MAT_VERSION=`cat VERSION`
 echo "MAT_VERSION = $MAT_VERSION" >> Makedefs

--- a/mod_auth_tkt.spec
+++ b/mod_auth_tkt.spec
@@ -2,7 +2,7 @@
 # Use "--define='apache 1'" to build a 'mod_auth_tkt1' package for apache1
 %define httpd httpd
 %define name mod_auth_tkt
-%if %{rhel} < 7
+%if 0%{?rhel} && 0%{?rhel} < 7
 %define apxs /usr/sbin/apxs
 %else
 %define apxs /usr/bin/apxs

--- a/mod_auth_tkt.spec
+++ b/mod_auth_tkt.spec
@@ -1,33 +1,26 @@
 
-# Use "--define='apache 1'" to build a 'mod_auth_tkt1' package for apache1
-%define httpd httpd
-%define name mod_auth_tkt
-%{!?_pkgdocdir:%global _pkgdocdir %{_docdir}/%{name}-%{version}}
-%if 0%{?rhel} && 0%{?rhel} < 7
-%global apxs /usr/sbin/apxs
-%else
-%global apxs /usr/bin/apxs
-%endif
-%{?_httpd_apxs:%global apxs %{_httpd_apxs}}
-%{?apache:%define httpd apache}
-%{?apache:%define name mod_auth_tkt1}
-%{?apache:%define apxs /usr/sbin/apxs1}
-%{!?_httpd_confdir:%global _httpd_confdir %{_sysconfdir}/%{httpd}/conf.d}
-%{!?_httpd_moddir:%global _httpd_moddir %{_libdir}/%{httpd}/modules}
+%{!?_httpd_apxs:       %{expand: %%global _httpd_apxs       %%{_sbindir}/apxs}}
+%{!?_httpd_confdir:    %{expand: %%global _httpd_confdir    %%{_sysconfdir}/httpd/conf.d}}
+%{!?_httpd_moddir:    %{expand: %%global _httpd_moddir    %%{_libdir}/httpd/modules}}
 
-%define perl_vendorlib %(eval "`perl -V:installvendorlib`"; echo $installvendorlib)
+%global name mod_auth_tkt
+
+%global _hardened_build 1
 
 Summary: Lightweight ticket-based authentication module for Apache.
 Name: %{name}
 Version: 2.3.99b1
-Release: 2%{?org_tag}%{?dist}
+Release: 3%{?dist}
 License: Apache
 Group: Applications/System
-Source: http://www.openfusion.com.au/labs/dist/mod_auth_tkt-%{version}.tar.gz
+Source: https://github.com/gavincarr/mod_auth_tkt/archive/%{version}/%{name}-%{version}.tar.gz
 URL: http://www.openfusion.com.au/labs/mod_auth_tkt/
-Buildroot: %_tmppath/%{name}-%{version}
-Requires: %{httpd}
-BuildRequires: %{httpd}-devel
+BuildRequires: httpd
+BuildRequires: httpd-devel
+BuildRequires: make
+BuildRequires: gcc
+BuildRequires: perl-podlators
+Requires: httpd
 
 %description
 mod_auth_tkt provides lightweight, repository-agnostic, ticket-based
@@ -37,75 +30,69 @@ authentication requires a user-supplied CGI or script of some kind - see
 the mod_auth_tkt-cgi package for perl cgi versions.
 
 %package cgi
-Release: 2%{?org_tag}%{?dist}
+Release: 3%{?dist}
 Summary: CGI scripts for mod_auth_tkt apache authentication modules.
 Group: Applications/System
-Requires: %{name} = %{version}
+BuildRequires: perl-generators
+Requires: %{name}%{?_isa} = %{version}-%{release}
 
 %description cgi
 Perl CGI scripts for use with mod_auth_tkt.
 
-
 %prep
-%setup -n mod_auth_tkt-%{version}
+%setup -q
 
 %build
 test %{debug} == 1 && DEBUG='--debug'
-MOD_PERL=`rpm -q mod_perl | grep '^mod_perl' || /bin/true`
-if [ -n "$MOD_PERL" -a %{test} == 1 ]; then
-  ./configure --apxs=%{apxs} --mandir=%{_mandir} --test $DEBUG
-  make
-  make test
-else
-  ./configure --apxs=%{apxs} --mandir=%{_mandir} $DEBUG
-  make
-fi
+./configure --apxs=%{_httpd_apxs} --mandir=%{_mandir} $DEBUG
+make
 
 %install
-test "$RPM_BUILD_ROOT" != "/" && rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT%{_httpd_moddir}
-mkdir -p $RPM_BUILD_ROOT%{_httpd_confdir}
-#mkdir -p $RPM_BUILD_ROOT%{_pkgdocdir}/cgi
-mkdir -p $RPM_BUILD_ROOT%{_pkgdocdir}/contrib
-mkdir -p $RPM_BUILD_ROOT/var/www/auth
-#mkdir -p $RPM_BUILD_ROOT/%{perl_vendorlib}/Apache
-if [ %{httpd} == apache ]; then
-  %{apxs} -i -n "auth_tkt" -S LIBEXECDIR=$RPM_BUILD_ROOT%{_httpd_moddir} src/mod_auth_tkt.so
-else
-  %{apxs} -i -n "auth_tkt" -S LIBEXECDIR=$RPM_BUILD_ROOT%{_httpd_moddir} src/mod_auth_tkt.la
-fi
-install -m 644 conf/02_auth_tkt.conf $RPM_BUILD_ROOT%{_httpd_confdir}
-install -m 644 conf/auth_tkt_cgi.conf $RPM_BUILD_ROOT%{_httpd_confdir}
-#cp cgi/Apache/* $RPM_BUILD_ROOT/%{perl_vendorlib}/Apache
-#cp -pr cgi/* $RPM_BUILD_ROOT%{_pkgdocdir}/cgi
-#rm -rf $RPM_BUILD_ROOT%{_pkgdocdir}/cgi/Apache
-cp -pr cgi/* $RPM_BUILD_ROOT/var/www/auth
-rm -rf $RPM_BUILD_ROOT/var/www/auth/Apache
-cp -pr contrib/* $RPM_BUILD_ROOT%{_pkgdocdir}/contrib
-rm -rf $RPM_BUILD_ROOT%{_pkgdocdir}/contrib/t
-cp -pr README* INSTALL LICENSE CREDITS $RPM_BUILD_ROOT%{_pkgdocdir}
+mkdir -p %{buildroot}%{_httpd_moddir} \
+         %{buildroot}%{_httpd_confdir} \
+         %{buildroot}%{_pkgdocdir}/contrib \
+         %{buildroot}/var/www/auth \
+         %{buildroot}/%{perl_vendorlib}/Apache
+%{_httpd_apxs} -i -n "auth_tkt" -S LIBEXECDIR=%{buildroot}%{_httpd_moddir} src/mod_auth_tkt.la
+install -m 644 conf/02_auth_tkt.conf %{buildroot}%{_httpd_confdir}
+install -m 644 conf/auth_tkt_cgi.conf %{buildroot}%{_httpd_confdir}
+cp cgi/Apache/* %{buildroot}/%{perl_vendorlib}/Apache
+cp -pr cgi/* %{buildroot}/var/www/auth
+rm -rf %{buildroot}/var/www/auth/Apache
+cp -pr contrib/* %{buildroot}%{_pkgdocdir}/contrib
+rm -rf %{buildroot}%{_pkgdocdir}/contrib/t
+cp -pr README* INSTALL LICENSE CREDITS %{buildroot}%{_pkgdocdir}
 cd doc
-make DESTDIR=$RPM_BUILD_ROOT install
+%make_install
+
+%check
+MOD_PERL=`rpm -q mod_perl | grep '^mod_perl' || /bin/true`
+if [ -n "$MOD_PERL" -a %{test} == 1 ]; then
+  make test
+fi
 
 %clean
-test "$RPM_BUILD_ROOT" != "/" && rm -rf $RPM_BUILD_ROOT
+rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root)
 %{_httpd_moddir}/*
-#%{perl_vendorlib}/Apache/AuthTkt.pm
 %doc %{_pkgdocdir}
 %attr(0640,root,apache) %config(noreplace) %{_httpd_confdir}/02_auth_tkt.conf
-%{_mandir}/*/*
+%{_mandir}/man3/*.3*
 
 %files cgi
 %defattr(-,root,root)
+%{perl_vendorlib}/Apache/AuthTkt.pm
 %attr(0640,root,apache) %config(noreplace) %{_httpd_confdir}/auth_tkt_cgi.conf
 %config(noreplace)/var/www/auth/AuthTktConfig.pm
 %config(noreplace)/var/www/auth/tkt.css
 /var/www/auth/*.cgi
 
 %changelog
+* Tue Jan 08 2019 Scott Shambarger <devel@shambarger.net> 2.3.99b1-3
+- Apply some Redhat packaging guidelines to spec
+
 * Mon Nov 16 2015 Scott Shambarger <devel@shambarger.net> 2.3.99b1-2
 - Cleanup spec and configure files
 

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -562,7 +562,7 @@ void mat_SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
         }
 
         /* Clean up state data: */
-        MEMSET_BZERO(context, sizeof(context));
+        MEMSET_BZERO(context, sizeof(*context));
         usedspace = 0;
 }
 
@@ -584,7 +584,7 @@ char *mat_SHA256_End(SHA256_CTX* context, char buffer[]) {
                 }
                 *b = (char)0;
         } else {
-                MEMSET_BZERO(context, sizeof(context));
+                MEMSET_BZERO(context, sizeof(*context));
         }
         MEMSET_BZERO(digest, SHA256_DIGEST_LENGTH);
         return buffer;
@@ -895,7 +895,7 @@ void mat_SHA512_Final(sha2_byte digest[], SHA512_CTX* context) {
         }
 
         /* Zero out state data */
-        MEMSET_BZERO(context, sizeof(context));
+        MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *mat_SHA512_End(SHA512_CTX* context, char buffer[]) {
@@ -916,7 +916,7 @@ char *mat_SHA512_End(SHA512_CTX* context, char buffer[]) {
                 }
                 *b = (char)0;
         } else {
-                MEMSET_BZERO(context, sizeof(context));
+                MEMSET_BZERO(context, sizeof(*context));
         }
         MEMSET_BZERO(digest, SHA512_DIGEST_LENGTH);
         return buffer;
@@ -971,7 +971,7 @@ void mat_SHA384_Final(sha2_byte digest[], SHA384_CTX* context) {
         }
 
         /* Zero out state data */
-        MEMSET_BZERO(context, sizeof(context));
+        MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *mat_SHA384_End(SHA384_CTX* context, char buffer[]) {
@@ -992,7 +992,7 @@ char *mat_SHA384_End(SHA384_CTX* context, char buffer[]) {
                 }
                 *b = (char)0;
         } else {
-                MEMSET_BZERO(context, sizeof(context));
+                MEMSET_BZERO(context, sizeof(*context));
         }
         MEMSET_BZERO(digest, SHA384_DIGEST_LENGTH);
         return buffer;


### PR DESCRIPTION
The configure script doesn't correctly handle locating the mandir directory, and uses 
the MANPATH environment variable directly  - which breaks if MANPATH is a true path with multiple path entries.

I've updated configure to handle this case, and added support for a --mandir parameter, and updated the rpm spec file to use it (passing the system _mandir value).

I also updated the spec file to generalize the handling of httpd conf and module directories, and added support for some of the fedora macros for documentation (which I believe are used in other distributions).
